### PR TITLE
ci: fix publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,26 +27,23 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - name: Auto-bump version from PR title
+      - name: Auto-bump version from commits
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          CURRENT_VERSION=$(node -p "require('./package.json').version")
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
 
-          # On squash merge, HEAD commit message is the PR title
-          PR_TITLE=$(git log -1 --pretty=format:"%s")
-
-          # Skip if this is a release commit (avoid infinite loop)
-          if echo "$PR_TITLE" | grep -qE "^release: v"; then
-            echo "Skipping version bump for release commit"
-            exit 0
+          if [ -z "$LAST_TAG" ]; then
+            COMMITS=$(git log --pretty=format:"%s" HEAD)
+          else
+            COMMITS=$(git log --pretty=format:"%s" "$LAST_TAG"..HEAD)
           fi
 
-          CURRENT_VERSION=$(node -p "require('./package.json').version")
-
           BUMP="patch"
-          if echo "$PR_TITLE" | grep -qiE "^feat(\(.+\))?!:|^BREAKING CHANGE:"; then
+          if echo "$COMMITS" | grep -qiE "^feat(\(.+\))?!:|^BREAKING CHANGE:"; then
             BUMP="major"
-          elif echo "$PR_TITLE" | grep -qiE "^feat(\(.+\))?:"; then
+          elif echo "$COMMITS" | grep -qiE "^feat(\(.+\))?:"; then
             BUMP="minor"
           fi
 
@@ -57,11 +54,12 @@ jobs:
             patch) NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))" ;;
           esac
 
+          # Bump version locally (no commit to avoid branch protection issues)
           npm version "$NEW_VERSION" --no-git-tag-version
-          git add package.json
-          git commit -m "release: v${NEW_VERSION}"
-          git tag "v${NEW_VERSION}"
-          git push origin main --tags
+
+          # Create tag via GitHub API (bypasses branch protection)
+          SHA=$(git rev-parse HEAD)
+          gh api repos/${{ github.repository }}/git/refs -f ref="refs/tags/v${NEW_VERSION}" -f sha="$SHA"
 
           echo "Bumped $CURRENT_VERSION → $NEW_VERSION ($BUMP)"
 


### PR DESCRIPTION
## Summary
- Switch from PR-title to commit-based version bumping
- Remove direct push to main (blocked by branch protection)
- Create git tags via GitHub API instead
- Bump version locally before `vsce publish` without committing

## Test plan
- [ ] Merge and verify publish workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)