### PR TITLE
ci: remove unsupported --packageManager flag from vsce

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,6 +67,6 @@ jobs:
 
       - run: pnpm run fetch-grammars
 
-      - run: pnpm dlx @vscode/vsce publish --no-dependencies --packageManager pnpm
+      - run: pnpm dlx @vscode/vsce publish --no-dependencies
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}


### PR DESCRIPTION
## Summary
- Remove `--packageManager pnpm` flag from `vsce publish` — no longer supported by newer `@vscode/vsce`

## Test plan
- [ ] Merge and verify publish succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)