### PR TITLE
fix: lower VS Code engine minimum to 1.93.0 for Cursor compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/PostHog/posthog-vscode"
   },
   "engines": {
-    "vscode": "^1.109.0"
+    "vscode": "^1.93.0"
   },
   "categories": [
     "Other"
@@ -269,7 +269,7 @@
     "@changesets/cli": "^2.29.0",
     "@types/mocha": "^10.0.10",
     "@types/node": "22.x",
-    "@types/vscode": "^1.109.0",
+    "@types/vscode": "^1.93.0",
     "@vscode/test-cli": "^0.0.12",
     "@vscode/test-electron": "^2.5.2",
     "@vscode/vsce": "^3.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
         specifier: 22.x
         version: 22.19.15
       '@types/vscode':
-        specifier: ^1.109.0
+        specifier: ^1.93.0
         version: 1.110.0
       '@vscode/test-cli':
         specifier: ^0.0.12


### PR DESCRIPTION
## Summary
- Lowers `engines.vscode` from `^1.109.0` to `^1.93.0` so Cursor users can install the extension
- Cursor 3.1.10 runs VS Code 1.105.1, which was below our previous minimum
- All VS Code APIs we use (`authentication`, `SecretStorage`, `registerUriHandler`, webviews, decorations, completions, code actions) have been stable since ~1.71-1.80 — no reason to require 1.109

## Test plan
- [x] `pnpm compile` succeeds
- [x] All 537 tests pass
- [ ] Verify installation works on Cursor

🤖 Generated with [Claude Code](https://claude.com/claude-code)