### PR TITLE
chore: add changeset for Cursor compatibility release

### DIFF
--- a/.changeset/cursor-compat-engine.md
+++ b/.changeset/cursor-compat-engine.md
@@ -1,0 +1,5 @@
+---
+"posthog-vscode": patch
+---
+
+Lower VS Code engine minimum to 1.93.0 for Cursor compatibility


### PR DESCRIPTION
## Summary
- Adds a patch changeset to trigger a release with the lowered VS Code engine minimum (`^1.93.0`) that was merged in #41
- This will publish a new version so Cursor users can install the extension

## Test plan
- [ ] CI passes
- [ ] Release pipeline triggers after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)