### PR TITLE
fix: allow user to copy auth URL for login

### DIFF
--- a/.changeset/fix-copy-auth-url.md
+++ b/.changeset/fix-copy-auth-url.md
@@ -1,0 +1,5 @@
+---
+"posthog-vscode": patch
+---
+
+Fix sign in failing when auth URL is copied instead of opened in a browser

--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,4 @@ grammars/
 .DS_Store
 .planning/
 .claude/worktrees/
-.devcontainer
 .pnpm-store

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ grammars/
 .DS_Store
 .planning/
 .claude/worktrees/
+.devcontainer
+.pnpm-store

--- a/src/commands/authCommands.ts
+++ b/src/commands/authCommands.ts
@@ -71,7 +71,7 @@ export function registerAuthCommands(
         } catch (err) {
             telemetry.capture('sign_in_failed');
             const detail = err instanceof Error ? err.message : 'Unknown error';
-            if (detail !== 'User did not consent to login.' && detail !== 'Authentication timed out') {
+            if (detail !== 'User did not consent to login.' && detail !== 'Authentication timed out' && detail !== 'Superseded by a new sign-in attempt.') {
                 vscode.window.showErrorMessage(`PostHog: Failed to sign in — ${detail}`);
             }
             await authService.setAuthenticated(false);

--- a/src/services/postHogAuthProvider.ts
+++ b/src/services/postHogAuthProvider.ts
@@ -114,9 +114,9 @@ export class PostHogAuthenticationProvider implements vscode.AuthenticationProvi
                         'Copy and paste the PostHog authentication URL into your browser to sign in',
                         'Copy URL',
                         'Cancel',
-                    ).then(choice => {
+                    ).then(async (choice) => {
                         if (choice === 'Copy URL') {
-                            vscode.env.clipboard.writeText(authUrlString);
+                            await vscode.env.clipboard.writeText(authUrlString);
                         } else if (choice === 'Cancel') {
                             clearTimeout(timeout);
                             this.pendingAuths.delete(state);

--- a/src/services/postHogAuthProvider.ts
+++ b/src/services/postHogAuthProvider.ts
@@ -117,7 +117,8 @@ export class PostHogAuthenticationProvider implements vscode.AuthenticationProvi
                     ).then(async (choice) => {
                         if (choice === 'Copy URL') {
                             await vscode.env.clipboard.writeText(authUrlString);
-                        } else if (choice === 'Cancel') {
+                        } else {
+                            // User clicked "Cancel" or dismissed the message
                             clearTimeout(timeout);
                             this.pendingAuths.delete(state);
                             reject(new Error('User did not consent to login.'));

--- a/src/services/postHogAuthProvider.ts
+++ b/src/services/postHogAuthProvider.ts
@@ -120,14 +120,14 @@ export class PostHogAuthenticationProvider implements vscode.AuthenticationProvi
             Promise.resolve(vscode.env.openExternal(authUrl)).then(opened => {
                 if (!opened) {
                     vscode.window.showInformationMessage(
-                        'Copy and paste the PostHog authentication URL into your browser to sign in',
+                        "PostHog: Couldn't open your browser. Copy the PostHog sign-in URL and paste it into your browser's address bar to continue.",
                         'Copy URL',
                         'Cancel',
                     ).then(async (choice) => {
                         if (choice === 'Copy URL') {
                             try {
                                 await vscode.env.clipboard.writeText(authUrlString);
-                                vscode.window.showInformationMessage('PostHog: Auth URL copied — paste it into your browser to finish signing in');
+                                vscode.window.showInformationMessage("PostHog: Auth URL copied — paste it into your browser's address bar to finish signing in");
                             } catch (error) {
                                 console.warn('[PostHog] Failed to copy auth URL to clipboard:', error);
                                 await vscode.window.showInputBox({

--- a/src/services/postHogAuthProvider.ts
+++ b/src/services/postHogAuthProvider.ts
@@ -97,7 +97,8 @@ export class PostHogAuthenticationProvider implements vscode.AuthenticationProvi
             scope: scopes.join(' '),
         });
 
-        const authUrl = vscode.Uri.parse(`${this.oauthAuthority}/authorize?${params.toString()}`);
+        const authUrlString = `${this.oauthAuthority}/authorize?${params.toString()}`;
+        const authUrl = vscode.Uri.parse(authUrlString);
 
         return new Promise<vscode.AuthenticationSession>((resolve, reject) => {
             const timeout = setTimeout(() => {
@@ -109,9 +110,19 @@ export class PostHogAuthenticationProvider implements vscode.AuthenticationProvi
 
             vscode.env.openExternal(authUrl).then(opened => {
                 if (!opened) {
-                    clearTimeout(timeout);
-                    this.pendingAuths.delete(state);
-                    reject(new Error('Failed to open browser for authentication'));
+                    vscode.window.showInformationMessage(
+                        'Copy and paste the PostHog authentication URL into your browser to sign in',
+                        'Copy URL',
+                        'Cancel',
+                    ).then(choice => {
+                        if (choice === 'Copy URL') {
+                            vscode.env.clipboard.writeText(authUrlString);
+                        } else if (choice === 'Cancel') {
+                            clearTimeout(timeout);
+                            this.pendingAuths.delete(state);
+                            reject(new Error('User did not consent to login.'));
+                        }
+                    });
                 }
             });
         });

--- a/src/services/postHogAuthProvider.ts
+++ b/src/services/postHogAuthProvider.ts
@@ -108,7 +108,7 @@ export class PostHogAuthenticationProvider implements vscode.AuthenticationProvi
 
             this.pendingAuths.set(state, { codeVerifier, resolve, reject, timeout });
 
-            vscode.env.openExternal(authUrl).then(opened => {
+            Promise.resolve(vscode.env.openExternal(authUrl)).then(opened => {
                 if (!opened) {
                     vscode.window.showInformationMessage(
                         'Copy and paste the PostHog authentication URL into your browser to sign in',
@@ -136,6 +136,11 @@ export class PostHogAuthenticationProvider implements vscode.AuthenticationProvi
                         }
                     });
                 }
+            })
+            .catch((error: Error) => {
+                clearTimeout(timeout);
+                this.pendingAuths.delete(state);
+                reject(error);
             });
         });
     }

--- a/src/services/postHogAuthProvider.ts
+++ b/src/services/postHogAuthProvider.ts
@@ -116,7 +116,18 @@ export class PostHogAuthenticationProvider implements vscode.AuthenticationProvi
                         'Cancel',
                     ).then(async (choice) => {
                         if (choice === 'Copy URL') {
-                            await vscode.env.clipboard.writeText(authUrlString);
+                            try {
+                                await vscode.env.clipboard.writeText(authUrlString);
+                                vscode.window.showInformationMessage('PostHog: Auth URL copied — paste it into your browser to finish signing in');
+                            } catch (error) {
+                                console.warn('[PostHog] Failed to copy auth URL to clipboard:', error);
+                                await vscode.window.showInputBox({
+                                    title: 'PostHog Authentication URL',
+                                    prompt: 'Could not copy automatically — copy this URL and open it in your browser to finish signing in',
+                                    value: authUrlString,
+                                    ignoreFocusOut: true,
+                                });
+                            }
                         } else {
                             // User clicked "Cancel" or dismissed the message
                             clearTimeout(timeout);

--- a/src/services/postHogAuthProvider.ts
+++ b/src/services/postHogAuthProvider.ts
@@ -58,12 +58,17 @@ export class PostHogAuthenticationProvider implements vscode.AuthenticationProvi
     }
 
     dispose(): void {
+        this.cancelPendingAuths(new Error('Auth provider disposed'));
+        this._onDidChangeSessions.dispose();
+    }
+
+    /** Reject and clear any in-flight sign-in attempts. */
+    private cancelPendingAuths(error: Error): void {
         for (const pending of this.pendingAuths.values()) {
             clearTimeout(pending.timeout);
-            pending.reject(new Error('Auth provider disposed'));
+            pending.reject(error);
         }
         this.pendingAuths.clear();
-        this._onDidChangeSessions.dispose();
     }
 
     // ── AuthenticationProvider interface ──
@@ -83,6 +88,10 @@ export class PostHogAuthenticationProvider implements vscode.AuthenticationProvi
     }
 
     async createSession(scopes: readonly string[]): Promise<vscode.AuthenticationSession> {
+        // A new sign-in attempt replaces any in-flight ones — e.g. a dismissed
+        // notification can leave a stale flow (with a ticking timeout) alive.
+        this.cancelPendingAuths(new Error('Superseded by a new sign-in attempt.'));
+
         const { codeVerifier, codeChallenge } = this.generatePKCE();
         const state = crypto.randomBytes(16).toString('hex');
 

--- a/src/test/regression/openExternalCopy.test.ts
+++ b/src/test/regression/openExternalCopy.test.ts
@@ -249,4 +249,36 @@ suite('Regression: openExternal returns false (Copy/Cancel/dismiss)', function (
             },
         );
     });
+
+    test('createSession() called again while one is pending: supersedes the old attempt', async function () {
+        this.timeout(2000);
+
+        await withOpenExternalFalseStubs(
+            { infoMessageChoice: 'Copy URL' },
+            async () => {
+                const firstSessionPromise = provider.createSession(SCOPES);
+                await delay(300);
+
+                assert.strictEqual(
+                    getPendingAuths(provider).size, 1,
+                    'First attempt should remain pending after "Copy URL" is chosen.',
+                );
+
+                const secondSessionPromise = provider.createSession(SCOPES);
+                secondSessionPromise.catch(() => { /* settled by dispose() in teardown */ });
+                await delay(300);
+
+                await assert.rejects(
+                    firstSessionPromise,
+                    /Superseded by a new sign-in attempt\./,
+                    'Bug regressed: starting a new sign-in attempt should reject any in-flight attempt with "Superseded by a new sign-in attempt."',
+                );
+
+                assert.strictEqual(
+                    getPendingAuths(provider).size, 1,
+                    'Bug regressed: the second sign-in attempt should still be tracked as pending.',
+                );
+            },
+        );
+    });
 });

--- a/src/test/regression/openExternalCopy.test.ts
+++ b/src/test/regression/openExternalCopy.test.ts
@@ -54,6 +54,8 @@ function delay(ms: number): Promise<void> {
 interface StubConfig {
     infoMessageChoice: string | undefined;
     onClipboardWrite?: (text: string) => void;
+    clipboardWriteError?: Error;
+    onShowInputBox?: (options: vscode.InputBoxOptions | undefined) => void;
 }
 
 async function withOpenExternalFalseStubs<T>(config: StubConfig, fn: () => Promise<T>): Promise<T> {
@@ -69,15 +71,27 @@ async function withOpenExternalFalseStubs<T>(config: StubConfig, fn: () => Promi
     const fakeClipboard: vscode.Clipboard = {
         readText: () => Promise.resolve(''),
         writeText: (text: string) => {
+            if (config.clipboardWriteError) {
+                return Promise.reject(config.clipboardWriteError);
+            }
             config.onClipboardWrite?.(text);
             return Promise.resolve();
         },
     };
     const restoreClipboard = stubProperty(vscode.env, 'clipboard', fakeClipboard);
+    const restoreShowInputBox = stubProperty(
+        vscode.window,
+        'showInputBox',
+        (options?: vscode.InputBoxOptions) => {
+            config.onShowInputBox?.(options);
+            return Promise.resolve(undefined);
+        },
+    );
 
     try {
         return await fn();
     } finally {
+        restoreShowInputBox();
         restoreClipboard();
         restoreShowInfo();
         restoreOpenExternal();
@@ -166,4 +180,39 @@ suite('Regression: openExternal returns false (Copy/Cancel/dismiss)', function (
             );
         });
     }
+
+    test('"Copy URL" clicked but clipboard.writeText fails: falls back to showInputBox with the URL', async () => {
+        let inputBoxOptions: vscode.InputBoxOptions | undefined;
+
+        await withOpenExternalFalseStubs(
+            {
+                infoMessageChoice: 'Copy URL',
+                clipboardWriteError: new Error('clipboard unavailable'),
+                onShowInputBox: options => { inputBoxOptions = options; },
+            },
+            async () => {
+                const sessionPromise = provider.createSession(SCOPES);
+                sessionPromise.catch(() => { /* settled by dispose() in teardown */ });
+
+                await delay(300);
+
+                assert.ok(
+                    inputBoxOptions !== undefined,
+                    'Bug regressed: when clipboard.writeText fails, showInputBox must be shown as a manual-copy fallback.',
+                );
+                assert.ok(
+                    !!inputBoxOptions?.value
+                        && inputBoxOptions.value.includes('client_id=')
+                        && inputBoxOptions.value.includes('/authorize?'),
+                    `Fallback input box should be pre-filled with the full auth URL, got: ${inputBoxOptions?.value}`,
+                );
+
+                assert.strictEqual(
+                    getPendingAuths(provider).size, 1,
+                    'Bug regressed: a clipboard write failure must NOT cancel the pending auth flow — ' +
+                    'the user can still copy the URL manually from the fallback input box.',
+                );
+            },
+        );
+    });
 });

--- a/src/test/regression/openExternalCopy.test.ts
+++ b/src/test/regression/openExternalCopy.test.ts
@@ -56,10 +56,16 @@ interface StubConfig {
     onClipboardWrite?: (text: string) => void;
     clipboardWriteError?: Error;
     onShowInputBox?: (options: vscode.InputBoxOptions | undefined) => void;
+    openExternalError?: Error;
 }
 
 async function withOpenExternalFalseStubs<T>(config: StubConfig, fn: () => Promise<T>): Promise<T> {
-    const restoreOpenExternal = stubProperty(vscode.env, 'openExternal', () => Promise.resolve(false));
+    const restoreOpenExternal = stubProperty(vscode.env, 'openExternal', () => {
+        if (config.openExternalError) {
+            return Promise.reject(config.openExternalError);
+        }
+        return Promise.resolve(false);
+    });
     const restoreShowInfo = stubProperty(
         vscode.window,
         'showInformationMessage',
@@ -211,6 +217,34 @@ suite('Regression: openExternal returns false (Copy/Cancel/dismiss)', function (
                     getPendingAuths(provider).size, 1,
                     'Bug regressed: a clipboard write failure must NOT cancel the pending auth flow — ' +
                     'the user can still copy the URL manually from the fallback input box.',
+                );
+            },
+        );
+    });
+
+    test('openExternal() itself rejects: cleans up pending state and rejects the session with that error', async function () {
+        // override Mocha's default 20s timeout for this test if it regresses,
+        // since sessionPromise will never settle due to the unhandled promise
+        // rejection from openExternal(). This will allow the test to timeout
+        // after 2s rather than 20s and speed up the overall test run.
+        this.timeout(2000);
+
+        const openExternalError = new Error('openExternal exploded');
+
+        await withOpenExternalFalseStubs(
+            { infoMessageChoice: undefined, openExternalError },
+            async () => {
+                const sessionPromise = provider.createSession(SCOPES);
+
+                await assert.rejects(
+                    sessionPromise,
+                    (err: Error) => err === openExternalError,
+                    'Bug regressed: if openExternal() itself rejects, the session promise must reject with that same error.',
+                );
+
+                assert.strictEqual(
+                    getPendingAuths(provider).size, 0,
+                    'Bug regressed: if openExternal() itself rejects, pending auth state must be cleaned up.',
                 );
             },
         );

--- a/src/test/regression/openExternalCopy.test.ts
+++ b/src/test/regression/openExternalCopy.test.ts
@@ -101,63 +101,68 @@ suite('Regression: openExternal returns false (Copy/Cancel/dismiss)', function (
         provider.dispose();
     });
 
-    test('"Copy URL" clicked: copies the auth URL and keeps the flow alive', async () => {
-        const written: string[] = [];
+    interface Case {
+        name: string;
+        infoMessageChoice: string | undefined;
+        expectRejection?: RegExp;
+        expectedPendingSize: number;
+        expectClipboardWrite: boolean;
+        bugMessage: string;
+    }
 
-        await withOpenExternalFalseStubs(
-            { infoMessageChoice: 'Copy URL', onClipboardWrite: text => written.push(text) },
-            async () => {
-                const sessionPromise = provider.createSession(SCOPES);
-                sessionPromise.catch(() => { /* exercised via dispose() in teardown */ });
+    const cases: Case[] = [
+        {
+            name: '"Copy URL" clicked: copies the auth URL and keeps the flow alive',
+            infoMessageChoice: 'Copy URL',
+            expectedPendingSize: 1,
+            expectClipboardWrite: true,
+            bugMessage: 'Bug regressed: clicking "Copy URL" should copy the auth URL to the clipboard and keep the flow alive.',
+        },
+        {
+            name: '"Cancel" clicked: rejects with "User did not consent to login." and cleans up',
+            infoMessageChoice: 'Cancel',
+            expectRejection: /User did not consent to login\./,
+            expectedPendingSize: 0,
+            expectClipboardWrite: false,
+            bugMessage: 'Bug regressed: clicking "Cancel" should reject with "User did not consent to login." (the string authCommands.ts suppresses) and clean up pending state.',
+        },
+        {
+            name: 'Notification dismissed (no button clicked): flow stays alive, no premature rejection',
+            infoMessageChoice: undefined,
+            expectedPendingSize: 1,
+            expectClipboardWrite: false,
+            bugMessage: 'Bug regressed: dismissing the notification must NOT cancel the auth flow — the user may still paste the URL into a browser manually and complete sign-in.',
+        },
+    ];
 
-                await delay(300);
+    for (const tc of cases) {
+        test(tc.name, async () => {
+            const written: string[] = [];
 
-                assert.ok(
-                    written.length > 0,
-                    'Bug regressed: clicking "Copy URL" should write the auth URL to the clipboard.',
-                );
-                assert.ok(
-                    written[0].includes('client_id=') && written[0].includes('/authorize?'),
-                    `Copied text should be the full auth URL, got: ${written[0]}`,
-                );
+            await withOpenExternalFalseStubs(
+                { infoMessageChoice: tc.infoMessageChoice, onClipboardWrite: text => written.push(text) },
+                async () => {
+                    const sessionPromise = provider.createSession(SCOPES);
+                    sessionPromise.catch(() => { /* asserted via assert.rejects below, or settled by dispose() in teardown */ });
 
-                assert.strictEqual(
-                    getPendingAuths(provider).size, 1,
-                    'Bug regressed: clicking "Copy URL" must NOT cancel the pending auth flow.',
-                );
-            },
-        );
-    });
+                    if (tc.expectRejection) {
+                        await assert.rejects(sessionPromise, tc.expectRejection, tc.bugMessage);
+                    } else {
+                        await delay(300);
+                    }
 
-    test('"Cancel" clicked: rejects with "User did not consent to login." and cleans up', async () => {
-        await withOpenExternalFalseStubs({ infoMessageChoice: 'Cancel' }, async () => {
-            const sessionPromise = provider.createSession(SCOPES);
+                    assert.strictEqual(getPendingAuths(provider).size, tc.expectedPendingSize, tc.bugMessage);
 
-            await assert.rejects(
-                sessionPromise,
-                /User did not consent to login\./,
-                'Bug regressed: clicking "Cancel" should reject with "User did not consent to login." (the string authCommands.ts suppresses).',
-            );
-
-            assert.strictEqual(
-                getPendingAuths(provider).size, 0,
-                'Pending auth state should be cleaned up after an explicit Cancel.',
+                    if (tc.expectClipboardWrite) {
+                        assert.ok(
+                            written.length > 0 && written[0].includes('client_id=') && written[0].includes('/authorize?'),
+                            `${tc.bugMessage} (expected the full auth URL on the clipboard, got: ${JSON.stringify(written)})`,
+                        );
+                    } else {
+                        assert.strictEqual(written.length, 0, `Clipboard should not be written to in this scenario, got: ${JSON.stringify(written)}`);
+                    }
+                },
             );
         });
-    });
-
-    test('Notification dismissed (no button clicked): flow stays alive, no premature rejection', async () => {
-        await withOpenExternalFalseStubs({ infoMessageChoice: undefined }, async () => {
-            const sessionPromise = provider.createSession(SCOPES);
-            sessionPromise.catch(() => { /* exercised via dispose() in teardown */ });
-
-            await delay(300);
-
-            assert.strictEqual(
-                getPendingAuths(provider).size, 1,
-                'Bug regressed: dismissing the notification must NOT cancel the auth flow — ' +
-                'the user may still paste the URL into a browser manually and complete sign-in.',
-            );
-        });
-    });
+    }
 });

--- a/src/test/regression/openExternalCopy.test.ts
+++ b/src/test/regression/openExternalCopy.test.ts
@@ -127,11 +127,12 @@ suite('Regression: openExternal returns false (Copy/Cancel/dismiss)', function (
             bugMessage: 'Bug regressed: clicking "Cancel" should reject with "User did not consent to login." (the string authCommands.ts suppresses) and clean up pending state.',
         },
         {
-            name: 'Notification dismissed (no button clicked): flow stays alive, no premature rejection',
+            name: 'Notification dismissed (no button clicked): rejects with "User did not consent to login." and cleans up',
             infoMessageChoice: undefined,
-            expectedPendingSize: 1,
+            expectRejection: /User did not consent to login\./,
+            expectedPendingSize: 0,
             expectClipboardWrite: false,
-            bugMessage: 'Bug regressed: dismissing the notification must NOT cancel the auth flow — the user may still paste the URL into a browser manually and complete sign-in.',
+            bugMessage: 'Bug regressed: dismissing the notification should reject with "User did not consent to login." (the string authCommands.ts suppresses) and clean up pending state.',
         },
     ];
 

--- a/src/test/regression/openExternalCopy.test.ts
+++ b/src/test/regression/openExternalCopy.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Regression test for: "Copy URL" / dismissed dialog killing the OAuth flow
+ *
+ * Bug:    When `vscode.env.openExternal()` returns `false` — which happens
+ *         both when the user chooses "Copy" in VS Code's open-link dialog
+ *         AND when they simply dismiss/cancel it (the API can't tell these
+ *         apart) — the code treated it as a hard browser failure: it
+ *         cleared the auth timeout, deleted the pending auth state, and
+ *         rejected the whole sign-in flow immediately. Users who copied
+ *         the URL to paste into a browser manually had their login killed
+ *         before they could finish.
+ * Fix:    Show an information message with "Copy URL" / "Cancel" actions.
+ *         "Copy URL" re-copies the auth URL and leaves the flow alive;
+ *         dismissing the message also leaves the flow alive (the 5-minute
+ *         timeout keeps running so a manual paste can still complete);
+ *         only an explicit "Cancel" click cleans up and rejects with
+ *         'User did not consent to login.' (a string authCommands.ts
+ *         already suppresses, matching the original dialog-cancel UX).
+ * Date:   2026-06-08
+ *
+ * This test should FAIL if the bug regresses.
+ */
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { PostHogAuthenticationProvider, SCOPES } from '../../services/postHogAuthProvider';
+
+class FakeSecrets implements vscode.SecretStorage {
+    private data = new Map<string, string>();
+    private emitter = new vscode.EventEmitter<vscode.SecretStorageChangeEvent>();
+    onDidChange = this.emitter.event;
+    async get(key: string): Promise<string | undefined> { return this.data.get(key); }
+    async store(key: string, value: string): Promise<void> { this.data.set(key, value); }
+    async delete(key: string): Promise<void> { this.data.delete(key); }
+    async keys(): Promise<string[]> { return [...this.data.keys()]; }
+}
+
+function stubProperty<T extends object>(obj: T, key: keyof T & string, value: unknown): () => void {
+    const original = Object.getOwnPropertyDescriptor(obj, key);
+    Object.defineProperty(obj, key, { configurable: true, value });
+    return () => {
+        if (original) {
+            Object.defineProperty(obj, key, original);
+        } else {
+            delete (obj as unknown as Record<string, unknown>)[key];
+        }
+    };
+}
+
+function delay(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+interface StubConfig {
+    infoMessageChoice: string | undefined;
+    onClipboardWrite?: (text: string) => void;
+}
+
+async function withOpenExternalFalseStubs<T>(config: StubConfig, fn: () => Promise<T>): Promise<T> {
+    const restoreOpenExternal = stubProperty(vscode.env, 'openExternal', () => Promise.resolve(false));
+    const restoreShowInfo = stubProperty(
+        vscode.window,
+        'showInformationMessage',
+        (..._args: unknown[]) => Promise.resolve(config.infoMessageChoice),
+    );
+    // `vscode.env.clipboard.writeText` is a non-configurable own property on the
+    // real Clipboard instance — it can't be redefined directly. Replace the whole
+    // `clipboard` property on `env` with a fake instead.
+    const fakeClipboard: vscode.Clipboard = {
+        readText: () => Promise.resolve(''),
+        writeText: (text: string) => {
+            config.onClipboardWrite?.(text);
+            return Promise.resolve();
+        },
+    };
+    const restoreClipboard = stubProperty(vscode.env, 'clipboard', fakeClipboard);
+
+    try {
+        return await fn();
+    } finally {
+        restoreClipboard();
+        restoreShowInfo();
+        restoreOpenExternal();
+    }
+}
+
+function getPendingAuths(provider: PostHogAuthenticationProvider): Map<string, unknown> {
+    return (provider as unknown as { pendingAuths: Map<string, unknown> }).pendingAuths;
+}
+
+suite('Regression: openExternal returns false (Copy/Cancel/dismiss)', function () {
+    this.timeout(20000);
+
+    let provider: PostHogAuthenticationProvider;
+
+    setup(() => {
+        provider = new PostHogAuthenticationProvider(new FakeSecrets());
+    });
+
+    teardown(() => {
+        provider.dispose();
+    });
+
+    test('"Copy URL" clicked: copies the auth URL and keeps the flow alive', async () => {
+        const written: string[] = [];
+
+        await withOpenExternalFalseStubs(
+            { infoMessageChoice: 'Copy URL', onClipboardWrite: text => written.push(text) },
+            async () => {
+                const sessionPromise = provider.createSession(SCOPES);
+                sessionPromise.catch(() => { /* exercised via dispose() in teardown */ });
+
+                await delay(300);
+
+                assert.ok(
+                    written.length > 0,
+                    'Bug regressed: clicking "Copy URL" should write the auth URL to the clipboard.',
+                );
+                assert.ok(
+                    written[0].includes('client_id=') && written[0].includes('/authorize?'),
+                    `Copied text should be the full auth URL, got: ${written[0]}`,
+                );
+
+                assert.strictEqual(
+                    getPendingAuths(provider).size, 1,
+                    'Bug regressed: clicking "Copy URL" must NOT cancel the pending auth flow.',
+                );
+            },
+        );
+    });
+
+    test('"Cancel" clicked: rejects with "User did not consent to login." and cleans up', async () => {
+        await withOpenExternalFalseStubs({ infoMessageChoice: 'Cancel' }, async () => {
+            const sessionPromise = provider.createSession(SCOPES);
+
+            await assert.rejects(
+                sessionPromise,
+                /User did not consent to login\./,
+                'Bug regressed: clicking "Cancel" should reject with "User did not consent to login." (the string authCommands.ts suppresses).',
+            );
+
+            assert.strictEqual(
+                getPendingAuths(provider).size, 0,
+                'Pending auth state should be cleaned up after an explicit Cancel.',
+            );
+        });
+    });
+
+    test('Notification dismissed (no button clicked): flow stays alive, no premature rejection', async () => {
+        await withOpenExternalFalseStubs({ infoMessageChoice: undefined }, async () => {
+            const sessionPromise = provider.createSession(SCOPES);
+            sessionPromise.catch(() => { /* exercised via dispose() in teardown */ });
+
+            await delay(300);
+
+            assert.strictEqual(
+                getPendingAuths(provider).size, 1,
+                'Bug regressed: dismissing the notification must NOT cancel the auth flow — ' +
+                'the user may still paste the URL into a browser manually and complete sign-in.',
+            );
+        });
+    });
+});

--- a/src/test/regression/openExternalCopy.test.ts
+++ b/src/test/regression/openExternalCopy.test.ts
@@ -11,9 +11,7 @@
  *         before they could finish.
  * Fix:    Show an information message with "Copy URL" / "Cancel" actions.
  *         "Copy URL" re-copies the auth URL and leaves the flow alive;
- *         dismissing the message also leaves the flow alive (the 5-minute
- *         timeout keeps running so a manual paste can still complete);
- *         only an explicit "Cancel" click cleans up and rejects with
+ *         only an explicit "Cancel" or dismiss cleans up and rejects with
  *         'User did not consent to login.' (a string authCommands.ts
  *         already suppresses, matching the original dialog-cancel UX).
  * Date:   2026-06-08
@@ -47,8 +45,19 @@ function stubProperty<T extends object>(obj: T, key: keyof T & string, value: un
     };
 }
 
-function delay(ms: number): Promise<void> {
-    return new Promise(resolve => setTimeout(resolve, ms));
+/** Returns a promise and a resolve callback — resolved when you call resolve(). */
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+    let resolve!: () => void;
+    const promise = new Promise<void>(r => { resolve = r; });
+    return { promise, resolve };
+}
+
+/** Returns true if the promise is still pending (has not resolved or rejected). */
+async function isPending(p: Promise<unknown>): Promise<boolean> {
+    let settled = false;
+    Promise.resolve(p).finally(() => { settled = true; });
+    await Promise.resolve(); // flush one microtask tick
+    return !settled;
 }
 
 interface StubConfig {
@@ -104,10 +113,6 @@ async function withOpenExternalFalseStubs<T>(config: StubConfig, fn: () => Promi
     }
 }
 
-function getPendingAuths(provider: PostHogAuthenticationProvider): Map<string, unknown> {
-    return (provider as unknown as { pendingAuths: Map<string, unknown> }).pendingAuths;
-}
-
 suite('Regression: openExternal returns false (Copy/Cancel/dismiss)', function () {
     this.timeout(20000);
 
@@ -125,7 +130,6 @@ suite('Regression: openExternal returns false (Copy/Cancel/dismiss)', function (
         name: string;
         infoMessageChoice: string | undefined;
         expectRejection?: RegExp;
-        expectedPendingSize: number;
         expectClipboardWrite: boolean;
         bugMessage: string;
     }
@@ -134,7 +138,6 @@ suite('Regression: openExternal returns false (Copy/Cancel/dismiss)', function (
         {
             name: '"Copy URL" clicked: copies the auth URL and keeps the flow alive',
             infoMessageChoice: 'Copy URL',
-            expectedPendingSize: 1,
             expectClipboardWrite: true,
             bugMessage: 'Bug regressed: clicking "Copy URL" should copy the auth URL to the clipboard and keep the flow alive.',
         },
@@ -142,26 +145,29 @@ suite('Regression: openExternal returns false (Copy/Cancel/dismiss)', function (
             name: '"Cancel" clicked: rejects with "User did not consent to login." and cleans up',
             infoMessageChoice: 'Cancel',
             expectRejection: /User did not consent to login\./,
-            expectedPendingSize: 0,
             expectClipboardWrite: false,
-            bugMessage: 'Bug regressed: clicking "Cancel" should reject with "User did not consent to login." (the string authCommands.ts suppresses) and clean up pending state.',
+            bugMessage: 'Bug regressed: clicking "Cancel" should reject with "User did not consent to login." (the string authCommands.ts suppresses).',
         },
         {
             name: 'Notification dismissed (no button clicked): rejects with "User did not consent to login." and cleans up',
             infoMessageChoice: undefined,
             expectRejection: /User did not consent to login\./,
-            expectedPendingSize: 0,
             expectClipboardWrite: false,
-            bugMessage: 'Bug regressed: dismissing the notification should reject with "User did not consent to login." (the string authCommands.ts suppresses) and clean up pending state.',
+            bugMessage: 'Bug regressed: dismissing the notification should reject with "User did not consent to login." (the string authCommands.ts suppresses).',
         },
     ];
 
     for (const tc of cases) {
-        test(tc.name, async () => {
+        test(tc.name, async function () {
+            this.timeout(2000);
             const written: string[] = [];
+            const clipboardWritten = deferred();
 
             await withOpenExternalFalseStubs(
-                { infoMessageChoice: tc.infoMessageChoice, onClipboardWrite: text => written.push(text) },
+                {
+                    infoMessageChoice: tc.infoMessageChoice,
+                    onClipboardWrite: text => { written.push(text); clipboardWritten.resolve(); },
+                },
                 async () => {
                     const sessionPromise = provider.createSession(SCOPES);
                     sessionPromise.catch(() => { /* asserted via assert.rejects below, or settled by dispose() in teardown */ });
@@ -169,10 +175,11 @@ suite('Regression: openExternal returns false (Copy/Cancel/dismiss)', function (
                     if (tc.expectRejection) {
                         await assert.rejects(sessionPromise, tc.expectRejection, tc.bugMessage);
                     } else {
-                        await delay(300);
+                        // Wait deterministically for the clipboard write, then confirm the
+                        // session promise is still alive (not yet resolved or rejected).
+                        await clipboardWritten.promise;
+                        assert.ok(await isPending(sessionPromise), tc.bugMessage);
                     }
-
-                    assert.strictEqual(getPendingAuths(provider).size, tc.expectedPendingSize, tc.bugMessage);
 
                     if (tc.expectClipboardWrite) {
                         assert.ok(
@@ -187,20 +194,22 @@ suite('Regression: openExternal returns false (Copy/Cancel/dismiss)', function (
         });
     }
 
-    test('"Copy URL" clicked but clipboard.writeText fails: falls back to showInputBox with the URL', async () => {
+    test('"Copy URL" clicked but clipboard.writeText fails: falls back to showInputBox with the URL', async function () {
+        this.timeout(2000);
         let inputBoxOptions: vscode.InputBoxOptions | undefined;
+        const inputBoxShown = deferred();
 
         await withOpenExternalFalseStubs(
             {
                 infoMessageChoice: 'Copy URL',
                 clipboardWriteError: new Error('clipboard unavailable'),
-                onShowInputBox: options => { inputBoxOptions = options; },
+                onShowInputBox: options => { inputBoxOptions = options; inputBoxShown.resolve(); },
             },
             async () => {
                 const sessionPromise = provider.createSession(SCOPES);
                 sessionPromise.catch(() => { /* settled by dispose() in teardown */ });
 
-                await delay(300);
+                await inputBoxShown.promise;
 
                 assert.ok(
                     inputBoxOptions !== undefined,
@@ -212,9 +221,8 @@ suite('Regression: openExternal returns false (Copy/Cancel/dismiss)', function (
                         && inputBoxOptions.value.includes('/authorize?'),
                     `Fallback input box should be pre-filled with the full auth URL, got: ${inputBoxOptions?.value}`,
                 );
-
-                assert.strictEqual(
-                    getPendingAuths(provider).size, 1,
+                assert.ok(
+                    await isPending(sessionPromise),
                     'Bug regressed: a clipboard write failure must NOT cancel the pending auth flow — ' +
                     'the user can still copy the URL manually from the fallback input box.',
                 );
@@ -222,11 +230,9 @@ suite('Regression: openExternal returns false (Copy/Cancel/dismiss)', function (
         );
     });
 
-    test('openExternal() itself rejects: cleans up pending state and rejects the session with that error', async function () {
-        // override Mocha's default 20s timeout for this test if it regresses,
-        // since sessionPromise will never settle due to the unhandled promise
-        // rejection from openExternal(). This will allow the test to timeout
-        // after 2s rather than 20s and speed up the overall test run.
+    test('openExternal() itself rejects: rejects the session with that error', async function () {
+        // Short per-test timeout: on regression, sessionPromise never settles (unhandled
+        // rejection from openExternal), so assert.rejects hangs. Fail fast at 2s.
         this.timeout(2000);
 
         const openExternalError = new Error('openExternal exploded');
@@ -241,42 +247,35 @@ suite('Regression: openExternal returns false (Copy/Cancel/dismiss)', function (
                     (err: Error) => err === openExternalError,
                     'Bug regressed: if openExternal() itself rejects, the session promise must reject with that same error.',
                 );
-
-                assert.strictEqual(
-                    getPendingAuths(provider).size, 0,
-                    'Bug regressed: if openExternal() itself rejects, pending auth state must be cleaned up.',
-                );
             },
         );
     });
 
     test('createSession() called again while one is pending: supersedes the old attempt', async function () {
         this.timeout(2000);
+        const firstClipboardWritten = deferred();
 
         await withOpenExternalFalseStubs(
-            { infoMessageChoice: 'Copy URL' },
+            { infoMessageChoice: 'Copy URL', onClipboardWrite: () => firstClipboardWritten.resolve() },
             async () => {
                 const firstSessionPromise = provider.createSession(SCOPES);
-                await delay(300);
+                firstSessionPromise.catch(() => { /* asserted via assert.rejects below */ });
 
-                assert.strictEqual(
-                    getPendingAuths(provider).size, 1,
-                    'First attempt should remain pending after "Copy URL" is chosen.',
-                );
+                // Wait deterministically for the first attempt to reach its pending state.
+                await firstClipboardWritten.promise;
+                assert.ok(await isPending(firstSessionPromise), 'First attempt should remain pending after "Copy URL" is chosen.');
 
                 const secondSessionPromise = provider.createSession(SCOPES);
                 secondSessionPromise.catch(() => { /* settled by dispose() in teardown */ });
-                await delay(300);
 
                 await assert.rejects(
                     firstSessionPromise,
                     /Superseded by a new sign-in attempt\./,
                     'Bug regressed: starting a new sign-in attempt should reject any in-flight attempt with "Superseded by a new sign-in attempt."',
                 );
-
-                assert.strictEqual(
-                    getPendingAuths(provider).size, 1,
-                    'Bug regressed: the second sign-in attempt should still be tracked as pending.',
+                assert.ok(
+                    await isPending(secondSessionPromise),
+                    'Bug regressed: the second sign-in attempt should still be pending.',
                 );
             },
         );


### PR DESCRIPTION
## What does this PR do?

If the user copies the URL rather than have VSCode open the URL for them, the extension immediately halts the login process, clears the timeout and state, and throws an error.

This change allows the user to copy the URL in case they want to inspect it, or open in a non-default browser. It also gives the user another chance to copy the URL if they accidentally dismiss the dialog; they can click the "Copy URL" button which appears on the information message that pops up at the bottom right corner of VSCode.

## How to test

1. Install the extension from scratch with no user session (or sign out of the existing session)
2. Click "Sign In with PostHog"
3. Click "Allow" in the dialog that appears
4. When the dialog asking "Do you want Code to open the external website?" appears, click "Copy" or "Cancel" (NOT "Open")
5. Click "Copy URL" in the information message appearing in the bottom right corner (optional - only need to do this if you clicked "Cancel" to dismiss the previous dialog)
6. Paste the URL into your browser
7. Sign into PostHog and authorize the extension to access your account
8. Allow the browser to open the callback URL in VSCode (if prompted)
9. Allow VSCode to open the callback URL (if prompted)
10. Verify the extension is signed in

## Checklist

- [x] Tested in Extension Development Host (F5)
- [x] No TypeScript errors (`pnpm compile`)
- [x] Tests pass (`pnpm test`)
- [x] Conventional commit message (feat:/fix:/ci:)
- [ ] **N/A** ~Telemetry events added for new user actions (if applicable)~
- [ ] **N/A** ~Settings documented in package.json (if new settings added)~

## Screenshots

Screenshot after clicking "Copy" instead of "Open"

### Before fix

<img width="454" height="54" alt="Screenshot 2026-06-08 at 13 21 14" src="https://github.com/user-attachments/assets/4cf631f1-129c-43e7-9452-45d43f1fe7c3" />

### After fix

<img width="465" height="109" alt="Screenshot 2026-06-08 at 13 11 25" src="https://github.com/user-attachments/assets/72ec474b-9a13-47e1-86cf-3fbc4bbb5545" />
