### PR TITLE
feat: improve login page with official product icons and colors

### DIFF
--- a/.changeset/plenty-goats-serve.md
+++ b/.changeset/plenty-goats-serve.md
@@ -1,0 +1,5 @@
+---
+"posthog-vscode": patch
+---
+
+feat: Update colors and explain more what the automagic setup does

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,7 +155,7 @@ All providers are constructed in `activate()`, passed their dependencies, and pu
 - **Types**: all PostHog API response shapes in `models/types.ts`
 - **FLAG_METHODS**: duplicated across files (each provider defines its own Set) — this is intentional, not a DRY violation to fix. Parity is enforced by `src/test/regression/methodSetParity.test.ts` — when adding a new flag method, you MUST update every provider AND `staleFlagService.FLAG_METHODS` AND `staleFlagService.POSTHOG_FLAG_METHODS` (the array used by cleanup edits — easy to miss).
 - **Colors**: `#4CBB17` green (active), `#F9BD2B` yellow (warning), `#1D4AFF` PostHog blue, `#E53E3E` red (error), `#F54E00` orange
-- **CSS variables**: `--ph-blue`, `--ph-yellow`, `--ph-orange`, `--ph-green`, `--ph-red`
+- **CSS variables**: `--ph-blue`, `--ph-blue-light`, `--ph-yellow`, `--ph-orange`, `--ph-green`, `--ph-red`, `--ph-red-light`, plus product colors `--ph-product-analytics`, `--ph-product-feature-flags`, `--ph-product-experiments`. Defined in `:root` of both `sidebar/sidebar.css` and `detail/detail.css` (separate webview documents — keep in sync). Never hardcode brand hex values in rules; for alpha tints use `color-mix(in srgb, var(--ph-x) N%, transparent)`
 - **Debounce**: 200ms on all decoration/highlight updates
 - **Error handling**: `.catch(() => {})` on startup cache loads; `try/catch` with `console.warn` in services
 - **Build**: `pnpm`, webpack → `dist/extension.js`, WASM files in `wasm/`

--- a/src/views/webview/detail/detail.css
+++ b/src/views/webview/detail/detail.css
@@ -1,8 +1,16 @@
 :root {
+    /* PostHog brand palette — keep in sync with sidebar/sidebar.css */
     --ph-blue: #1D4AFF;
-    --ph-green: #4CBB17;
-    --ph-red: #F44;
+    --ph-blue-light: #5B8AFF;   /* readable blue text on tinted backgrounds */
     --ph-yellow: #F9BD2B;
+    --ph-orange: #F54E00;
+    --ph-green: #4CBB17;
+    --ph-red: #F44336;
+    --ph-red-light: #FF4444;    /* readable red text on tinted backgrounds */
+    /* Official product colors (frontend/src/scenes/welcome/productBranding.ts in posthog/posthog) */
+    --ph-product-analytics: #2F80FA;
+    --ph-product-feature-flags: #30ABC6;
+    --ph-product-experiments: #B62AD9;
     --radius: 8px;
 }
 * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -44,13 +52,13 @@ body {
     font-size: 11px;
     font-weight: 600;
 }
-.badge.active { background: rgba(76, 187, 23, 0.15); color: #4CBB17; }
+.badge.active { background: color-mix(in srgb, var(--ph-green) 15%, transparent); color: var(--ph-green); }
 .badge.inactive { background: rgba(255,255,255,0.08); opacity: 0.6; }
-.badge.running { background: rgba(29, 74, 255, 0.15); color: #5B8AFF; }
-.badge.complete { background: rgba(76, 187, 23, 0.15); color: #4CBB17; }
+.badge.running { background: color-mix(in srgb, var(--ph-blue) 15%, transparent); color: var(--ph-blue-light); }
+.badge.complete { background: color-mix(in srgb, var(--ph-green) 15%, transparent); color: var(--ph-green); }
 .badge.draft { background: rgba(255,255,255,0.08); opacity: 0.6; }
-.badge.error { background: rgba(244, 68, 68, 0.15); color: #f66; }
-.badge.resolved { background: rgba(76, 187, 23, 0.15); color: #4CBB17; }
+.badge.error { background: color-mix(in srgb, var(--ph-red-light) 15%, transparent); color: var(--ph-red-light); }
+.badge.resolved { background: color-mix(in srgb, var(--ph-green) 15%, transparent); color: var(--ph-green); }
 
 .hero-actions { display: flex; gap: 8px; flex-wrap: wrap; }
 .btn {
@@ -176,7 +184,7 @@ body {
     border-radius: 4px; padding: 6px 8px; font-size: 12px; text-align: right;
 }
 .variant-remove {
-    background: none; border: none; color: var(--ph-red); cursor: pointer;
+    background: none; border: none; color: var(--ph-red-light); cursor: pointer;
     font-size: 18px; padding: 0 4px; opacity: 0.5; line-height: 1;
 }
 .variant-remove:hover { opacity: 1; }
@@ -208,7 +216,7 @@ body {
 }
 .save-status { font-size: 12px; }
 .save-status.ok { color: var(--ph-green); }
-.save-status.err { color: var(--ph-red); }
+.save-status.err { color: var(--ph-red-light); }
 
 /* ── Tables ── */
 .data-table { width: 100%; border-collapse: collapse; }
@@ -227,13 +235,13 @@ body {
 .sub { font-size: 10px; opacity: 0.45; }
 .delta { font-weight: 500; }
 .delta.up { color: var(--ph-green); }
-.delta.down { color: var(--ph-red); }
+.delta.down { color: var(--ph-red-light); }
 .win-badge {
     font-weight: 600; padding: 2px 8px; border-radius: 4px; font-size: 11px;
     display: inline-block;
 }
-.win-badge.sig-win { background: rgba(76,187,23,0.12); color: #4CBB17; }
-.win-badge.sig-lose { background: rgba(244,68,68,0.08); color: #f66; }
+.win-badge.sig-win { background: color-mix(in srgb, var(--ph-green) 12%, transparent); color: var(--ph-green); }
+.win-badge.sig-lose { background: color-mix(in srgb, var(--ph-red-light) 8%, transparent); color: var(--ph-red-light); }
 
 /* ── CI bars ── */
 .ci-section { margin-top: 10px; }
@@ -243,7 +251,7 @@ body {
 .ci-zero { position: absolute; top: 0; bottom: 0; width: 1px; background: var(--vscode-foreground); opacity: 0.15; }
 .ci-bar { position: absolute; top: 2px; height: 6px; border-radius: 3px; opacity: 0.7; }
 .ci-bar.pos { background: var(--ph-green); }
-.ci-bar.neg { background: var(--ph-red); }
+.ci-bar.neg { background: var(--ph-red-light); }
 .ci-bar.neu { background: var(--vscode-foreground); opacity: 0.25; }
 .ci-range { font-family: var(--vscode-editor-font-family); opacity: 0.4; white-space: nowrap; flex-shrink: 0; }
 
@@ -356,8 +364,8 @@ body {
 .conclusion {
     padding: 12px 16px; border-radius: var(--radius); margin-bottom: 16px; font-size: 13px;
 }
-.conclusion.won { background: rgba(76,187,23,0.08); }
-.conclusion.lost { background: rgba(244,68,68,0.08); }
+.conclusion.won { background: color-mix(in srgb, var(--ph-green) 8%, transparent); }
+.conclusion.lost { background: color-mix(in srgb, var(--ph-red-light) 8%, transparent); }
 .conclusion-comment { margin-top: 4px; opacity: 0.6; font-size: 12px; font-style: italic; }
 
 /* ── Meta ── */
@@ -387,7 +395,7 @@ body {
 }
 .session-card:hover {
     border-color: var(--ph-blue);
-    background: rgba(29, 74, 255, 0.04);
+    background: color-mix(in srgb, var(--ph-blue) 4%, transparent);
 }
 .session-header {
     display: flex;
@@ -457,7 +465,7 @@ body {
 /* ── Experiment card ── */
 .experiment-card {
     border-color: var(--ph-blue);
-    background: rgba(29, 74, 255, 0.04);
+    background: color-mix(in srgb, var(--ph-blue) 4%, transparent);
 }
 .experiment-info { display: flex; flex-direction: column; gap: 8px; }
 .experiment-header {

--- a/src/views/webview/sidebar/sidebar.css
+++ b/src/views/webview/sidebar/sidebar.css
@@ -303,7 +303,6 @@ html { height: 100vh; overflow: hidden; }
     gap: 10px;
 }
 .welcome-feature-icon {
-    font-size: 16px;
     width: 28px;
     height: 28px;
     display: flex;
@@ -312,6 +311,23 @@ html { height: 100vh; overflow: hidden; }
     border-radius: 6px;
     background: rgba(29, 74, 255, 0.1);
     flex-shrink: 0;
+}
+.welcome-feature-icon svg {
+    width: 16px;
+    height: 16px;
+}
+/* Official product brand colors (frontend/src/scenes/welcome/productBranding.ts in posthog/posthog) */
+.welcome-feature-icon--flags {
+    color: #30ABC6;
+    background: rgba(48, 171, 198, 0.12);
+}
+.welcome-feature-icon--experiments {
+    color: #B62AD9;
+    background: rgba(182, 42, 217, 0.12);
+}
+.welcome-feature-icon--analytics {
+    color: #2F80FA;
+    background: rgba(47, 128, 250, 0.12);
 }
 .welcome-feature-text {
     display: flex;
@@ -430,6 +446,14 @@ html { height: 100vh; overflow: hidden; }
 }
 .vscode-light .wizard-cta-btn:hover {
     background: linear-gradient(135deg, rgba(29, 74, 255, 0.14), rgba(245, 78, 0, 0.12), rgba(249, 189, 43, 0.12));
+}
+.wizard-cta-desc {
+    font-size: 11px;
+    opacity: 0.5;
+    line-height: 1.4;
+    max-width: 260px;
+    margin-top: 8px;
+    text-align: center;
 }
 
 /* ── Welcome divider ── */

--- a/src/views/webview/sidebar/sidebar.css
+++ b/src/views/webview/sidebar/sidebar.css
@@ -1,9 +1,16 @@
 :root {
+    /* PostHog brand palette — keep in sync with detail/detail.css */
     --ph-blue: #1D4AFF;
+    --ph-blue-light: #5B8AFF;   /* readable blue text on tinted backgrounds */
     --ph-yellow: #F9BD2B;
     --ph-orange: #F54E00;
     --ph-green: #4CBB17;
     --ph-red: #F44336;
+    --ph-red-light: #FF4444;    /* readable red text on tinted backgrounds */
+    /* Official product colors (frontend/src/scenes/welcome/productBranding.ts in posthog/posthog) */
+    --ph-product-analytics: #2F80FA;
+    --ph-product-feature-flags: #30ABC6;
+    --ph-product-experiments: #B62AD9;
 }
 
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -309,25 +316,24 @@ html { height: 100vh; overflow: hidden; }
     align-items: center;
     justify-content: center;
     border-radius: 6px;
-    background: rgba(29, 74, 255, 0.1);
+    background: color-mix(in srgb, var(--ph-blue) 10%, transparent);
     flex-shrink: 0;
 }
 .welcome-feature-icon svg {
     width: 16px;
     height: 16px;
 }
-/* Official product brand colors (frontend/src/scenes/welcome/productBranding.ts in posthog/posthog) */
 .welcome-feature-icon--flags {
-    color: #30ABC6;
-    background: rgba(48, 171, 198, 0.12);
+    color: var(--ph-product-feature-flags);
+    background: color-mix(in srgb, var(--ph-product-feature-flags) 12%, transparent);
 }
 .welcome-feature-icon--experiments {
-    color: #B62AD9;
-    background: rgba(182, 42, 217, 0.12);
+    color: var(--ph-product-experiments);
+    background: color-mix(in srgb, var(--ph-product-experiments) 12%, transparent);
 }
 .welcome-feature-icon--analytics {
-    color: #2F80FA;
-    background: rgba(47, 128, 250, 0.12);
+    color: var(--ph-product-analytics);
+    background: color-mix(in srgb, var(--ph-product-analytics) 12%, transparent);
 }
 .welcome-feature-text {
     display: flex;
@@ -397,7 +403,7 @@ html { height: 100vh; overflow: hidden; }
     cursor: pointer;
     transition: transform 0.15s, box-shadow 0.15s;
     letter-spacing: 0.2px;
-    background: linear-gradient(135deg, rgba(29, 74, 255, 0.12), rgba(245, 78, 0, 0.12), rgba(249, 189, 43, 0.12));
+    background: linear-gradient(135deg, color-mix(in srgb, var(--ph-blue) 12%, transparent), color-mix(in srgb, var(--ph-orange) 12%, transparent), color-mix(in srgb, var(--ph-yellow) 12%, transparent));
     color: var(--vscode-foreground);
     display: flex;
     align-items: center;
@@ -407,8 +413,8 @@ html { height: 100vh; overflow: hidden; }
 }
 .wizard-cta-btn:hover {
     transform: translateY(-1px);
-    box-shadow: 0 4px 16px rgba(29, 74, 255, 0.15), 0 2px 8px rgba(245, 78, 0, 0.1);
-    background: linear-gradient(135deg, rgba(29, 74, 255, 0.2), rgba(245, 78, 0, 0.18), rgba(249, 189, 43, 0.18));
+    box-shadow: 0 4px 16px color-mix(in srgb, var(--ph-blue) 15%, transparent), 0 2px 8px color-mix(in srgb, var(--ph-orange) 10%, transparent);
+    background: linear-gradient(135deg, color-mix(in srgb, var(--ph-blue) 20%, transparent), color-mix(in srgb, var(--ph-orange) 18%, transparent), color-mix(in srgb, var(--ph-yellow) 18%, transparent));
 }
 .wizard-cta-sparkle {
     font-size: 15px;
@@ -436,16 +442,16 @@ html { height: 100vh; overflow: hidden; }
 .wizard-cta-magic span:nth-child(12) { animation-delay: 1.65s; }
 .wizard-cta-magic span:nth-child(13) { animation-delay: 1.8s; }
 @keyframes wizardColorCycle {
-    0%, 100% { color: #1D4AFF; }
-    33%      { color: #F54E00; }
-    66%      { color: #F9BD2B; }
+    0%, 100% { color: var(--ph-blue); }
+    33%      { color: var(--ph-orange); }
+    66%      { color: var(--ph-yellow); }
 }
 .vscode-light .wizard-cta-btn {
     border-color: rgba(0, 0, 0, 0.1);
-    background: linear-gradient(135deg, rgba(29, 74, 255, 0.08), rgba(245, 78, 0, 0.08), rgba(249, 189, 43, 0.08));
+    background: linear-gradient(135deg, color-mix(in srgb, var(--ph-blue) 8%, transparent), color-mix(in srgb, var(--ph-orange) 8%, transparent), color-mix(in srgb, var(--ph-yellow) 8%, transparent));
 }
 .vscode-light .wizard-cta-btn:hover {
-    background: linear-gradient(135deg, rgba(29, 74, 255, 0.14), rgba(245, 78, 0, 0.12), rgba(249, 189, 43, 0.12));
+    background: linear-gradient(135deg, color-mix(in srgb, var(--ph-blue) 14%, transparent), color-mix(in srgb, var(--ph-orange) 12%, transparent), color-mix(in srgb, var(--ph-yellow) 12%, transparent));
 }
 .wizard-cta-desc {
     font-size: 11px;
@@ -499,7 +505,7 @@ html { height: 100vh; overflow: hidden; }
     align-items: center;
     justify-content: center;
     border-radius: 6px;
-    background: rgba(245, 78, 0, 0.1);
+    background: color-mix(in srgb, var(--ph-orange) 10%, transparent);
     flex-shrink: 0;
 }
 .wizard-feature-text {
@@ -653,7 +659,7 @@ html { height: 100vh; overflow: hidden; }
     padding: 0;
     flex-shrink: 0;
 }
-.flag-toggle.active { background: #4CBB17; }
+.flag-toggle.active { background: var(--ph-green); }
 .flag-toggle-knob {
     display: block;
     width: 14px;
@@ -731,7 +737,7 @@ html { height: 100vh; overflow: hidden; }
 .flag-variant-remove {
     background: none;
     border: none;
-    color: var(--vscode-errorForeground, #f44);
+    color: var(--vscode-errorForeground, var(--ph-red-light));
     cursor: pointer;
     font-size: 16px;
     padding: 0 4px;
@@ -786,8 +792,8 @@ html { height: 100vh; overflow: hidden; }
     font-size: 11px;
     opacity: 0.7;
 }
-.flag-save-status.success { color: #4CBB17; opacity: 1; }
-.flag-save-status.error { color: var(--vscode-errorForeground, #f44); opacity: 1; }
+.flag-save-status.success { color: var(--ph-green); opacity: 1; }
+.flag-save-status.error { color: var(--vscode-errorForeground, var(--ph-red-light)); opacity: 1; }
 
 /* ── Experiment results ── */
 .exp-conclusion {
@@ -796,8 +802,8 @@ html { height: 100vh; overflow: hidden; }
     margin-bottom: 14px;
     font-size: 12px;
 }
-.exp-conclusion.won { background: rgba(76, 187, 23, 0.1); }
-.exp-conclusion.lost { background: rgba(244, 68, 68, 0.1); }
+.exp-conclusion.won { background: color-mix(in srgb, var(--ph-green) 10%, transparent); }
+.exp-conclusion.lost { background: color-mix(in srgb, var(--ph-red-light) 10%, transparent); }
 .exp-conclusion-comment {
     margin-top: 4px;
     opacity: 0.7;
@@ -846,23 +852,23 @@ html { height: 100vh; overflow: hidden; }
     border-top: 1px solid var(--vscode-panel-border);
     border-bottom: none;
 }
-.exp-table tr.winner td { color: #4CBB17; }
+.exp-table tr.winner td { color: var(--ph-green); }
 .exp-table tr.loser td { }
 .exp-sub {
     font-size: 9px;
     opacity: 0.5;
 }
 .exp-delta { font-weight: 500; }
-.exp-delta.positive { color: #4CBB17; }
-.exp-delta.negative { color: #f44; }
+.exp-delta.positive { color: var(--ph-green); }
+.exp-delta.negative { color: var(--ph-red-light); }
 .exp-win-pct {
     font-weight: 600;
     padding: 1px 5px;
     border-radius: 3px;
     font-size: 10px;
 }
-.exp-win-pct.winner { background: rgba(76, 187, 23, 0.15); color: #4CBB17; }
-.exp-win-pct.loser { background: rgba(244, 68, 68, 0.1); color: #f44; }
+.exp-win-pct.winner { background: color-mix(in srgb, var(--ph-green) 15%, transparent); color: var(--ph-green); }
+.exp-win-pct.loser { background: color-mix(in srgb, var(--ph-red-light) 10%, transparent); color: var(--ph-red-light); }
 
 .exp-metric-block {
     background: var(--vscode-textCodeBlock-background, rgba(255,255,255,0.04));
@@ -931,8 +937,8 @@ html { height: 100vh; overflow: hidden; }
     border-radius: 3px;
     opacity: 0.7;
 }
-.exp-ci-bar.positive { background: #4CBB17; }
-.exp-ci-bar.negative { background: #f44; }
+.exp-ci-bar.positive { background: var(--ph-green); }
+.exp-ci-bar.negative { background: var(--ph-red-light); }
 .exp-ci-bar.neutral { background: var(--vscode-foreground); opacity: 0.3; }
 .exp-ci-range {
     font-family: var(--vscode-editor-font-family);
@@ -974,7 +980,7 @@ html { height: 100vh; overflow: hidden; }
     align-items: center;
     justify-content: center;
     border-radius: 4px;
-    background: rgba(29, 74, 255, 0.12);
+    background: color-mix(in srgb, var(--ph-blue) 12%, transparent);
     flex-shrink: 0;
 }
 .insight-card-title {
@@ -1171,7 +1177,7 @@ html { height: 100vh; overflow: hidden; }
 /* ── Experiment progress bar ── */
 .exp-progress { margin: 8px 0; }
 .exp-progress-bar { height: 6px; background: var(--vscode-editorWidget-border); border-radius: 3px; overflow: hidden; }
-.exp-progress-fill { height: 100%; background: var(--ph-blue, #1D4AFF); border-radius: 3px; transition: width 0.3s; }
+.exp-progress-fill { height: 100%; background: var(--ph-blue); border-radius: 3px; transition: width 0.3s; }
 .exp-progress-text { font-size: 11px; color: var(--vscode-descriptionForeground); margin-top: 4px; }
 
 /* ── Experiment summary counts ── */
@@ -1219,8 +1225,8 @@ html { height: 100vh; overflow: hidden; }
 
 /* ── Confirmation bar ── */
 .confirm-bar {
-    background: rgba(249, 189, 43, 0.15);
-    border: 1px solid var(--ph-yellow, #F9BD2B);
+    background: color-mix(in srgb, var(--ph-yellow) 15%, transparent);
+    border: 1px solid var(--ph-yellow);
     border-radius: 6px;
     padding: 8px 12px;
     margin: 8px 0;
@@ -1240,7 +1246,7 @@ html { height: 100vh; overflow: hidden; }
     flex-shrink: 0;
 }
 .confirm-bar .btn-confirm {
-    background: var(--ph-yellow, #F9BD2B);
+    background: var(--ph-yellow);
     color: #000;
     border: none;
     padding: 4px 12px;
@@ -1267,12 +1273,12 @@ html { height: 100vh; overflow: hidden; }
     align-items: center;
     gap: 8px;
     padding: 12px;
-    background: rgba(229, 62, 62, 0.1);
-    border: 1px solid var(--ph-red, #E53E3E);
+    background: color-mix(in srgb, var(--ph-red) 10%, transparent);
+    border: 1px solid var(--ph-red);
     border-radius: 6px;
     margin: 8px 12px;
 }
-.error-icon { color: var(--ph-red, #E53E3E); font-size: 16px; }
+.error-icon { color: var(--ph-red); font-size: 16px; }
 .error-message { flex: 1; font-size: 12px; color: var(--vscode-foreground); }
 .error-retry {
     background: transparent;
@@ -1289,7 +1295,7 @@ html { height: 100vh; overflow: hidden; }
 /* ── Help link ── */
 .help-link {
     font-size: 11px;
-    color: var(--ph-blue, #1D4AFF);
+    color: var(--ph-blue);
     cursor: pointer;
     opacity: 0.8;
     text-decoration: none;
@@ -1311,9 +1317,9 @@ html { height: 100vh; overflow: hidden; }
 }
 .filter-btn:hover { opacity: 1; }
 .filter-btn.active {
-    background: var(--ph-blue, #1D4AFF);
+    background: var(--ph-blue);
     color: #fff;
-    border-color: var(--ph-blue, #1D4AFF);
+    border-color: var(--ph-blue);
     opacity: 1;
 }
 
@@ -1387,7 +1393,7 @@ html { height: 100vh; overflow: hidden; }
 }
 .feedback-emoji.selected {
     border-color: var(--ph-blue);
-    background: rgba(29, 74, 255, 0.1);
+    background: color-mix(in srgb, var(--ph-blue) 10%, transparent);
 }
 .feedback-emoji-icon {
     font-size: 26px;
@@ -1449,7 +1455,7 @@ html { height: 100vh; overflow: hidden; }
     justify-content: center;
     gap: 6px;
     padding: 10px 16px;
-    background: rgba(76, 187, 23, 0.12);
+    background: color-mix(in srgb, var(--ph-green) 12%, transparent);
     border: 1px solid var(--ph-green);
     border-radius: 6px;
     font-size: 13px;

--- a/src/views/webview/sidebar/sidebar.html
+++ b/src/views/webview/sidebar/sidebar.html
@@ -5,29 +5,38 @@
     <p class="welcome-subtitle">Your feature flags, experiments, and analytics — right in your editor.</p>
     <div class="welcome-features">
         <div class="welcome-feature">
-            <span class="welcome-feature-icon">&#x2691;</span>
+            <span class="welcome-feature-icon welcome-feature-icon--flags">
+                <!-- IconFlag from @posthog/icons -->
+                <svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M4 3.75C4 2.784 4.784 2 5.75 2h13.631c1.398 0 2.232 1.558 1.457 2.72l-2.594 3.891a.25.25 0 0 0 0 .278l2.594 3.89c.775 1.163-.059 2.721-1.457 2.721H5.5v5.75a.75.75 0 0 1-1.5 0V3.75ZM5.5 14h13.881a.25.25 0 0 0 .209-.389l-2.594-3.89a1.75 1.75 0 0 1 0-1.942l2.594-3.89a.25.25 0 0 0-.209-.389H5.75a.25.25 0 0 0-.25.25V14Z"/></svg>
+            </span>
             <div class="welcome-feature-text">
                 <span class="welcome-feature-name">Feature Flags</span>
                 <span class="welcome-feature-desc">See flag status inline, autocomplete flag keys</span>
             </div>
         </div>
         <div class="welcome-feature">
-            <span class="welcome-feature-icon">&#x2697;</span>
+            <span class="welcome-feature-icon welcome-feature-icon--experiments">
+                <!-- IconFlask from @posthog/icons -->
+                <svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path fill-rule="evenodd" clip-rule="evenodd" d="M7 6.75A.75.75 0 0 1 7.75 6h8.5a.75.75 0 0 1 0 1.5H16v3.233a31.851 31.851 0 0 0 .885 1.006c.322.358.665.738.995 1.132.72.86 1.434 1.842 1.83 2.948.18.505.29 1.04.29 1.597A4.584 4.584 0 0 1 15.416 22H8.584A4.584 4.584 0 0 1 4 17.416c0-.558.11-1.092.29-1.597.396-1.106 1.11-2.089 1.83-2.948.33-.394.673-.774.995-1.132l.093-.104c.287-.317.553-.616.792-.902V7.5h-.25A.75.75 0 0 1 7 6.75Zm2.5.75v3.763l-.164.206c-.31.386-.662.78-1.013 1.17l-.091.101c-.325.361-.65.722-.962 1.095-.345.41-.66.82-.928 1.234l.098-.015c.895-.137 2.053-.275 2.99-.25 1.137.03 2 .302 2.774.545l.021.007c.779.245 1.469.46 2.384.484.797.02 1.846-.1 2.725-.234.211-.032.41-.065.59-.095-.313-.566-.728-1.12-1.194-1.676-.312-.373-.637-.734-.962-1.095l-.091-.101c-.351-.39-.703-.784-1.013-1.17l-.164-.206V7.5h-5Z"/><path d="M11 4a1 1 0 1 1-2 0 1 1 0 0 1 2 0Zm4-1.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0Z"/></svg>
+            </span>
             <div class="welcome-feature-text">
                 <span class="welcome-feature-name">Experiments</span>
                 <span class="welcome-feature-desc">Track experiment variants and results</span>
             </div>
         </div>
         <div class="welcome-feature">
-            <span class="welcome-feature-icon">&#x1F4CA;</span>
+            <span class="welcome-feature-icon welcome-feature-icon--analytics">
+                <!-- IconGraph from @posthog/icons -->
+                <svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M11 3.001a1.5 1.5 0 0 0-1.5 1.5v15a1.5 1.5 0 0 0 1.5 1.5h2a1.5 1.5 0 0 0 1.5-1.5v-15a1.5 1.5 0 0 0-1.5-1.5h-2Zm-6.5 10a1.5 1.5 0 0 0-1.5 1.5v5a1.5 1.5 0 0 0 1.5 1.5h2a1.5 1.5 0 0 0 1.5-1.5v-5a1.5 1.5 0 0 0-1.5-1.5h-2Zm11.5-3.5a1.5 1.5 0 0 1 1.5-1.5h2a1.5 1.5 0 0 1 1.5 1.5v10a1.5 1.5 0 0 1-1.5 1.5h-2a1.5 1.5 0 0 1-1.5-1.5v-10Z"/></svg>
+            </span>
             <div class="welcome-feature-text">
                 <span class="welcome-feature-name">Analytics</span>
                 <span class="welcome-feature-desc">View saved insights and trends</span>
             </div>
         </div>
     </div>
-    <button class="sign-in-btn sign-in-btn--primary" id="btn-sign-in">Sign In with PostHog</button>
-    <button class="sign-in-btn sign-in-btn--dev" id="btn-sign-in-dev" style="display:none;">Sign In (localhost:8010)</button>
+    <button class="sign-in-btn sign-in-btn--primary" id="btn-sign-in">Sign in with PostHog</button>
+    <button class="sign-in-btn sign-in-btn--dev" id="btn-sign-in-dev" style="display:none;">Sign in (localhost:8010)</button>
     <div class="welcome-divider" id="wizard-divider" style="display:none;">
         <span class="welcome-divider-line"></span>
         <span class="welcome-divider-text">or</span>
@@ -37,6 +46,7 @@
         <span class="wizard-cta-sparkle">&#x2728;</span>
         Set up PostHog <span class="wizard-cta-magic"><span>a</span><span>u</span><span>t</span><span>o</span><span>m</span><span>a</span><span>g</span><span>i</span><span>c</span><span>a</span><span>l</span><span>l</span><span>y</span></span>
     </button>
+    <p class="wizard-cta-desc" id="wizard-cta-desc" style="display:none;">New to PostHog? An AI wizard analyzes your codebase and installs the SDK for you — right from your terminal.</p>
 </div>
 
 <!-- Wizard info screen -->

--- a/src/views/webview/sidebar/sidebar.js
+++ b/src/views/webview/sidebar/sidebar.js
@@ -1294,8 +1294,10 @@ window.addEventListener('message', e => {
             var wizardVisible = msg.wizardEnabled || msg.isDev;
             var wizardDivider = document.getElementById('wizard-divider');
             var wizardBtn = document.getElementById('btn-show-wizard');
+            var wizardDesc = document.getElementById('wizard-cta-desc');
             if (wizardDivider) { wizardDivider.style.display = wizardVisible ? '' : 'none'; }
             if (wizardBtn) { wizardBtn.style.display = wizardVisible ? '' : 'none'; }
+            if (wizardDesc) { wizardDesc.style.display = wizardVisible ? '' : 'none'; }
             // Update project name + host in header
             var projNameEl = document.getElementById('project-name');
             if (projNameEl) {


### PR DESCRIPTION
- Replace unicode placeholder icons with real SVGs from @posthog/icons
  (IconFlag, IconFlask, IconGraph) tinted with each product's official
  brand color from posthog/posthog productBranding.ts
- Lowercase 'in' in the sign-in buttons
- Add a short description under the 'Set up PostHog automagically'
  button explaining what the wizard does

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
