### PR TITLE
fix: correct dev MCP server port to 8787

### DIFF
--- a/src/providers/mcpServerDefinitionProvider.ts
+++ b/src/providers/mcpServerDefinitionProvider.ts
@@ -4,7 +4,7 @@ import * as vscode from 'vscode';
 export const MCP_PROVIDER_ID = 'posthog.mcp';
 export const MCP_SERVER_LABEL = 'PostHog';
 export const MCP_SERVER_URL = 'https://mcp.posthog.com/mcp';
-export const MCP_DEV_SERVER_URL = 'http://localhost:6767/mcp';
+export const MCP_DEV_SERVER_URL = 'http://localhost:8787/mcp';
 
 /**
  * Contributes the PostHog remote MCP server to VS Code's MCP integration,

--- a/src/test/providers/mcpServerDefinitionProvider.test.ts
+++ b/src/test/providers/mcpServerDefinitionProvider.test.ts
@@ -42,7 +42,7 @@ suite('PostHogMcpServerDefinitionProvider', () => {
         assert.strictEqual(def.uri.toString(), MCP_DEV_SERVER_URL);
         const url = new URL(MCP_DEV_SERVER_URL);
         assert.strictEqual(url.hostname, 'localhost');
-        assert.strictEqual(url.port, '6767');
+        assert.strictEqual(url.port, '8787');
     });
 
     test('Test and Production modes use the official MCP server', () => {


### PR DESCRIPTION
The F5 dev-mode MCP URL added in #48 pointed at `localhost:6767`; the local MCP server actually runs on **8787**. Updates `MCP_DEV_SERVER_URL` and the corresponding test assertion. Dev-only change (only affects `ExtensionMode.Development`), so no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)