### PR TITLE
fix(ci): sign the commits this workflow creates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,17 +98,33 @@ jobs:
                   echo "new-version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
                   echo "was-released=true" >> "$GITHUB_OUTPUT"
 
+            # Commits through the GitHub API so it carries GitHub's signature, which
+            # the org-wide signed-commits ruleset requires. A plain `git push` is
+            # rejected.
             - name: Commit version bump
+              id: commit-version-bump
               if: steps.version.outputs.was-released == 'true'
+              uses: planetscale/ghcommit-action@a6b150b81dca5dd027baa898604418eec9e11465 # v0.2.22
+              with:
+                  commit_message: 'chore: release v${{ steps.version.outputs.new-version }}'
+                  repo: ${{ github.repository }}
+                  branch: ${{ github.ref_name }}
               env:
-                  VERSION: ${{ steps.version.outputs.new-version }}
+                  GITHUB_TOKEN: ${{ steps.releaser.outputs.token }}
+
+            # ghcommit-action creates the commit on the remote without moving the
+            # local checkout, so the tag below would otherwise point at the
+            # pre-bump commit.
+            - name: Sync checkout to release commit
+              if: steps.commit-version-bump.outputs.commit-hash != ''
+              env:
+                  COMMIT_HASH: ${{ steps.commit-version-bump.outputs.commit-hash }}
               run: |
-                  git add -A
-                  git commit -m "chore: release v$VERSION"
-                  git push
+                  git fetch origin "$GITHUB_REF_NAME"
+                  git reset --hard "$COMMIT_HASH"
 
             - name: Create Git tag
-              if: steps.version.outputs.was-released == 'true'
+              if: steps.commit-version-bump.outputs.commit-hash != ''
               env:
                   GH_TOKEN: ${{ steps.releaser.outputs.token }}
                   VERSION: ${{ steps.version.outputs.new-version }}


### PR DESCRIPTION
## Summary

Makes the workflow that commits in this repo produce **signed** commits.

Commits created with plain `git` are unsigned. PostHog is rolling the org-wide "Require signed commits" ruleset out to every repo, and this workflow would be rejected with `GH013` once it applies here. Routing the commit through the GitHub API instead means GitHub signs it with its own key, so it lands verified.

Found while inventorying which workflows across the org still create unsigned commits. `planetscale/ghcommit-action` is the pattern already in use in `posthog-js`, `posthog-roblox`, `brand`, `charts` and the SDK release fleet.

## Changes

The release version bump is committed through the API, followed by a checkout sync so the tag still points at the bump.

## Testing

Not run end to end. The sync step matters: `ghcommit-action` creates the commit remotely without moving the local checkout, so without it `git tag` would have tagged the pre-bump commit. Same pattern already in use in `posthog-roblox`.
